### PR TITLE
Fix equality assertions on Transaction

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,6 @@
 use serde::{Serialize, Deserialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Transaction {
     pub sender: String,
     pub recipient: String,


### PR DESCRIPTION
## Summary
- derive `PartialEq` on `Transaction` so tests can compare transactions

## Testing
- `cargo test --quiet` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_687aa2f9993c8326a98bf3dcd7d5276f