### PR TITLE
Fix tokio features for async modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "time"] }
 
 # Arc/Mutex/threading are built-in (std), no crate needed.
 


### PR DESCRIPTION
## Summary
- enable Tokio's `net`, `io-util`, and `time` features so async networking compiles

## Testing
- `cargo test --locked --offline` *(fails: no matching package named `clap` found)*


------
https://chatgpt.com/codex/tasks/task_e_687ab36b3e308326ac857dd89a07b3a6