### PR TITLE
Fix network message send locking across await

### DIFF
--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -137,8 +137,11 @@ pub async fn handle_client_with_chain(mut stream: TcpStream, blockchain: Arc<Mut
                     }
                     NetworkMessage::ChainRequest(requestor_addr) => {
                         println!("[SERIALIZED] Received ChainRequest from {}", requestor_addr);
-                        let chain = blockchain.lock().unwrap();
-                        let response = NetworkMessage::ChainResponse(chain.chain.clone());
+                        let chain_blocks = {
+                            let chain = blockchain.lock().unwrap();
+                            chain.chain.clone()
+                        };
+                        let response = NetworkMessage::ChainResponse(chain_blocks);
                         let _ = send_message(&requestor_addr, &response).await;
                     }
                     NetworkMessage::ChainResponse(their_chain) => {


### PR DESCRIPTION
## Summary
- ensure chain mutex guard isn't held across await in `handle_client_with_chain`

## Testing
- `cargo test --quiet` *(fails: could not access crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_687b06cc0cc483268f3476e50b7e9d20