### PR TITLE
Add setup script and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,13 @@ Each node will print received messages and you can send transactions via the int
 
 Uncomment them in `Cargo.toml` when needed.
 
+
+## Setup for tests and documentation
+
+Run the helper script to ensure all crates are fetched, tests pass and docs are built:
+
+```bash
+./setup.sh
+```
+
+The script installs Rust with `rustup` if necessary, fetches dependencies, runs `cargo test` and generates documentation with `cargo doc`.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+# Setup script to fetch dependencies, run tests, and build documentation
+
+# Install Rust toolchain if cargo is not available
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "Rust toolchain not found. Installing via rustup..."
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    source "$HOME/.cargo/env"
+fi
+
+# Fetch all dependencies to ensure crates are available offline
+cargo fetch
+
+# Run the project tests
+cargo test
+
+# Generate documentation without pulling in dependencies' docs
+cargo doc --no-deps
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add `setup.sh` to install Rust, fetch dependencies, run tests, and build docs
- document the new script in the README

## Testing
- `bash setup.sh` *(fails: requested URL returned error because network access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687b8bb32da083268fc5b92c5333daed