### PR TITLE
Fix Secp256k1 compile errors

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -67,6 +67,7 @@ mod tests {
     use super::*;
     use secp256k1::Secp256k1;
     use rand::rngs::OsRng;
+    use rand::RngCore;
     use hex;
 
     #[test]
@@ -81,7 +82,10 @@ mod tests {
         let mut bc = Blockchain::new();
         let secp = Secp256k1::new();
         let mut rng = OsRng;
-        let (sk, pk) = secp.generate_keypair(&mut rng);
+        let mut sk_bytes = [0u8; 32];
+        rng.fill_bytes(&mut sk_bytes);
+        let sk = SecretKey::from_slice(&sk_bytes).unwrap();
+        let pk = PublicKey::from_secret_key(&secp, &sk);
         let mut tx = Transaction { sender: hex::encode(pk.serialize()), recipient: "b".into(), amount: 1, signature: None };
         tx.sign(&sk);
         bc.add_block(vec![tx.clone()], Some("addr".into()));
@@ -97,7 +101,10 @@ mod tests {
         let mut bc = Blockchain::new();
         let secp = Secp256k1::new();
         let mut rng = OsRng;
-        let (sk, pk) = secp.generate_keypair(&mut rng);
+        let mut sk_bytes = [0u8; 32];
+        rng.fill_bytes(&mut sk_bytes);
+        let sk = SecretKey::from_slice(&sk_bytes).unwrap();
+        let pk = PublicKey::from_secret_key(&secp, &sk);
         let mut tx = Transaction { sender: hex::encode(pk.serialize()), recipient: "b".into(), amount: 2, signature: None };
         tx.sign(&sk);
         bc.add_block(vec![tx], Some("addr".into()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use secp256k1::Secp256k1;
 use secp256k1::SecretKey;
 use secp256k1::PublicKey;
 use rand::rngs::OsRng;
+use rand::RngCore;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -45,7 +46,10 @@ async fn main() {
     // --- Generate keypair for signing ---
     let secp = Secp256k1::new();
     let mut rng = OsRng;
-    let (secret_key, public_key) = secp.generate_keypair(&mut rng);
+    let mut sk_bytes = [0u8; 32];
+    rng.fill_bytes(&mut sk_bytes);
+    let secret_key = SecretKey::from_slice(&sk_bytes).unwrap();
+    let public_key = PublicKey::from_secret_key(&secp, &secret_key);
     let my_address = hex::encode(public_key.serialize());
 
     // --- Initialize peer list ---

--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -328,6 +328,7 @@ mod tests {
     use std::time::Duration;
     use secp256k1::Secp256k1;
     use rand::rngs::OsRng;
+    use rand::RngCore;
     use hex;
 
     #[test]
@@ -347,7 +348,10 @@ mod tests {
         let mut their = Blockchain::new();
         let secp = Secp256k1::new();
         let mut rng = OsRng;
-        let (sk, pk) = secp.generate_keypair(&mut rng);
+        let mut sk_bytes = [0u8; 32];
+        rng.fill_bytes(&mut sk_bytes);
+        let sk = SecretKey::from_slice(&sk_bytes).unwrap();
+        let pk = PublicKey::from_secret_key(&secp, &sk);
         let mut tx = Transaction { sender: hex::encode(pk.serialize()), recipient: "b".into(), amount: 1, signature: None };
         tx.sign(&sk);
         their.add_block(vec![tx], Some("addr".into()));
@@ -400,7 +404,10 @@ mod tests {
         let mut their_chain = Blockchain::new();
         let secp = Secp256k1::new();
         let mut rng = OsRng;
-        let (sk, pk) = secp.generate_keypair(&mut rng);
+        let mut sk_bytes = [0u8; 32];
+        rng.fill_bytes(&mut sk_bytes);
+        let sk = SecretKey::from_slice(&sk_bytes).unwrap();
+        let pk = PublicKey::from_secret_key(&secp, &sk);
         let mut tx = Transaction { sender: hex::encode(pk.serialize()), recipient: "y".into(), amount: 5, signature: None };
         tx.sign(&sk);
         their_chain.add_block(vec![tx], Some("addr".into()));


### PR DESCRIPTION
## Summary
- switch away from `generate_keypair`
- produce keypairs manually using `OsRng`

## Testing
- `cargo test` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_687bc3a12f2083268911ae7bb55c2d0b