### PR TITLE
Fix missing Secp256k1 imports in tests

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -65,7 +65,7 @@ impl Blockchain {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use secp256k1::Secp256k1;
+    use secp256k1::{Secp256k1, SecretKey, PublicKey};
     use rand::rngs::OsRng;
     use rand::RngCore;
     use hex;

--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -326,7 +326,7 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
-    use secp256k1::Secp256k1;
+    use secp256k1::{Secp256k1, SecretKey, PublicKey};
     use rand::rngs::OsRng;
     use rand::RngCore;
     use hex;


### PR DESCRIPTION
## Summary
- fix compile errors by importing `SecretKey` and `PublicKey` in test modules

## Testing
- `./setup.sh` *(fails: `cargo fetch` & tests skipped due to missing crates)*

------
https://chatgpt.com/codex/tasks/task_e_687bd5f989108326b8ea05955978a388