### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Format
+        run: cargo fmt -- --check
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+      - name: Test
+        run: cargo test --verbose
+      - name: Doc
+        run: cargo doc --no-deps

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WWChain
 
+[![CI](https://github.com/OWNER/wwchain/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/wwchain/actions/workflows/ci.yml)
+
 WWChain is a minimal blockchain prototype written in Rust. Each node maintains its own chain, shares blocks and transactions over TCP and keeps a simple list of peers. The project exists mostly for learning and experimentation.
 
 ## Building


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to format, lint, test and build docs
- show CI status badge in the README

## Testing
- `cargo fmt -- --check` *(fails: 'cargo-fmt' is not installed)*
- `cargo test` *(fails to fetch crates index)*
- `cargo doc --no-deps` *(fails to fetch crates index)*

------
https://chatgpt.com/codex/tasks/task_e_687d3076be048326bfaa60795c782df1