### PR TITLE
Add security disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Run the helper script to ensure all crates are fetched, tests pass and docs are 
 
 The script installs Rust with `rustup` if necessary, fetches dependencies, runs `cargo test` and generates documentation with `cargo doc`.
 
+## Security/Disclaimer
+
+This prototype is for learning and experimentation only. It has not been audited or hardened and should **not** be used to manage real cryptocurrency or any sensitive data.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add Security/Disclaimer section to README

## Testing
- `./setup.sh` *(fails: cargo fetch/tests/docs skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687d31ad38bc83269d39472207f89a1c