### PR TITLE
Add cargo fmt step

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ Run the helper script to ensure all crates are fetched, tests pass and docs are 
 ./setup.sh
 ```
 
-The script installs Rust with `rustup` if necessary, fetches dependencies, runs `cargo test` and generates documentation with `cargo doc`.
+The script installs Rust with `rustup` if necessary, fetches dependencies,
+formats the code with `cargo fmt --all`, runs `cargo test` and generates
+documentation with `cargo doc`.
 
 ## Security/Disclaimer
 

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,9 @@ fi
 # still be used.
 cargo fetch || echo "cargo fetch failed - continuing with any cached crates"
 
+# Format the code
+cargo fmt --all || echo "cargo fmt failed"
+
 # Run the project tests
 cargo test --offline || echo "Tests skipped due to missing crates"
 


### PR DESCRIPTION
## Summary
- add `cargo fmt --all` before tests in `setup.sh`
- mention code formatting in docs

## Testing
- `bash setup.sh` *(fails: cargo fmt failed, tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687d32cd34488326b7a9337329de03c3