### PR TITLE
Improve error handling

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -25,7 +25,13 @@ impl Transaction {
 
     pub fn sign(&mut self, sk: &SecretKey) {
         let secp = Secp256k1::new();
-        let msg = Message::from_slice(&self.message_bytes()).expect("32 bytes");
+        let msg = match Message::from_slice(&self.message_bytes()) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("Failed to create signing message: {}", e);
+                return;
+            }
+        };
         let sig = secp.sign_ecdsa(&msg, sk);
         self.signature = Some(hex::encode(sig.serialize_compact()));
     }
@@ -52,7 +58,10 @@ impl Transaction {
             Err(_) => return false,
         };
         let secp = Secp256k1::verification_only();
-        let msg = Message::from_slice(&self.message_bytes()).expect("32 bytes");
+        let msg = match Message::from_slice(&self.message_bytes()) {
+            Ok(m) => m,
+            Err(_) => return false,
+        };
         secp.verify_ecdsa(&msg, &sig, &pubkey).is_ok()
     }
 }


### PR DESCRIPTION
## Summary
- avoid `unwrap` on secret key generation and server start
- check mutex locks and IO errors in `main`
- handle serialization failures and mutex poisoning in networking code
- guard signing and verification against invalid message creation

## Testing
- `cargo test --locked --offline --quiet` *(fails: no matching package named `hex` found)*

------
https://chatgpt.com/codex/tasks/task_e_687d36739cb08326ab38ce4fde5f88f5