### PR TITLE
Add ledger validation for blockchain transactions

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -9,10 +9,14 @@ pub fn load_chain(path: &str) -> io::Result<Blockchain> {
     let mut data = String::new();
     file.read_to_string(&mut data)?;
     let blocks: Vec<Block> = serde_json::from_str(&data)?;
-    let chain = Blockchain { chain: blocks };
+    let mut chain = Blockchain {
+        chain: blocks,
+        balances: std::collections::HashMap::new(),
+    };
     if !chain.is_valid_chain() {
         return Err(io::Error::new(ErrorKind::InvalidData, "invalid blockchain"));
     }
+    chain.recompute_balances();
     Ok(chain)
 }
 


### PR DESCRIPTION
## Summary
- track balances in `Blockchain`
- validate overspending and double spend when adding blocks
- rebuild balances when loading chain
- extend tests for ledger logic

## Testing
- `cargo test --offline` *(fails: no matching package named `hex` found)*
- `cargo test` *(fails: failed to download crates from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_687d3abf8c408326bfba2190a67e4f41