### PR TITLE
Fix borrow of moved value in blockchain test

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -145,7 +145,7 @@ mod tests {
         assert_eq!(bc.chain.len(), 2);
         let last = bc.chain.last().unwrap();
         assert_eq!(last.index, 1);
-        assert_eq!(last.transactions, vec![tx]);
+        assert_eq!(last.transactions, vec![tx.clone()]);
         assert_eq!(last.prev_hash, bc.chain[0].hash);
         assert_eq!(bc.balances.get(&tx.sender).copied(), Some(0));
         assert_eq!(bc.balances.get(&"b".to_string()).copied(), Some(1));


### PR DESCRIPTION
## Summary
- fix borrow/move issue in `test_add_block`

## Testing
- `cargo test` *(fails: could not fetch crates due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_687d5151f30c83269cb30aed4b842e96