### PR TITLE
Fix tests expecting funded senders

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -141,6 +141,7 @@ mod tests {
             signature: None,
         };
         tx.sign(&sk);
+        bc.balances.insert(tx.sender.clone(), 1);
         bc.add_block(vec![tx.clone()], Some("addr".into()));
         assert_eq!(bc.chain.len(), 2);
         let last = bc.chain.last().unwrap();
@@ -214,6 +215,7 @@ mod tests {
             signature: None,
         };
         tx.sign(&sk);
+        bc.balances.insert(tx.sender.clone(), 2);
         bc.add_block(vec![tx], Some("addr".into()));
         assert!(bc.is_valid_chain());
         bc.chain[1].prev_hash = "bad".into();

--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -490,6 +490,7 @@ mod tests {
             signature: None,
         };
         tx.sign(&sk);
+        their.balances.insert(tx.sender.clone(), 1);
         their.add_block(vec![tx], Some("addr".into()));
         handle_chain_response(&mut local, their.chain.clone());
         assert_eq!(local.chain.len(), 2);
@@ -551,6 +552,7 @@ mod tests {
             signature: None,
         };
         tx.sign(&sk);
+        their_chain.balances.insert(tx.sender.clone(), 5);
         their_chain.add_block(vec![tx], Some("addr".into()));
         tokio::spawn(async move {
             if let Ok((mut stream, _)) = listener.accept().await {
@@ -630,6 +632,7 @@ mod tests {
 
         {
             let mut chain1 = bc1.lock().unwrap();
+            chain1.balances.insert(tx.sender.clone(), 3);
             chain1.add_block(vec![tx.clone()], Some(addr1.to_string()));
         }
 


### PR DESCRIPTION
## Summary
- ensure sender balances exist in blockchain tests
- fund senders in network tests so blocks are accepted

## Testing
- `cargo test --quiet` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_687d54cde41c8326b4005aed4f6aa62f