### PR TITLE
Fix parity_db transaction import

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,4 @@
-use parity_db::{Db, Options};
-use parity_db::transaction::Transaction;
+use parity_db::{Db, Options, Transaction};
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, ErrorKind};


### PR DESCRIPTION
## Summary
- correct `Transaction` import path for parity-db

## Testing
- `cargo fmt --all` *(fails: rustfmt component missing)*
- `cargo build --offline` *(fails: dependencies not cached)*

------
https://chatgpt.com/codex/tasks/task_e_687e62f642a08326ac4a130dd7c13369