### PR TITLE
Switch blockchain persistence to RocksDB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "time"] }
-parity-db = "0.3"
+rocksdb = "0.21"
 
 # Arc/Mutex/threading are built-in (std), no crate needed.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Each node will print received messages and you can send transactions via the int
 
 ## Chain persistence
 
-Blocks are now stored in a [parity-db](https://crates.io/crates/parity-db) database. The database lives in a directory (default `chain_db`) which can be changed with the `--chain-dir` argument. Each block is written atomically so crashes cannot corrupt previously committed data.
+Blocks are now stored in a [RocksDB](https://crates.io/crates/rocksdb) database. The database lives in a directory (default `chain_db`) which can be changed with the `--chain-dir` argument. Each block is written atomically so crashes cannot corrupt previously committed data.
 
 ## Optional dependencies
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,4 @@
-use parity_db::{Db, Options};
-use parity_db::transaction::Transaction;
+use rocksdb::{Options, DB, WriteBatch};
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, ErrorKind};
@@ -8,16 +7,17 @@ use std::path::Path;
 use crate::block::Block;
 use crate::blockchain::Blockchain;
 
-/// Load the blockchain from a parity-db database.
+/// Load the blockchain from a RocksDB database.
 /// Each block is stored under its index key and serialized as JSON.
 pub fn load_chain(path: &str) -> io::Result<Blockchain> {
-    let mut opts = Options::with_columns(Path::new(path), 1);
-    let db = Db::open_or_create(&opts).map_err(|e| io::Error::new(ErrorKind::Other, e))?;
+    let mut opts = Options::default();
+    opts.create_if_missing(false);
+    let db = DB::open(&opts, path).map_err(|e| io::Error::new(ErrorKind::Other, e))?;
     let mut blocks = Vec::new();
     let mut index = 0u64;
     loop {
         let key = index.to_le_bytes();
-        match db.get(0, &key).map_err(|e| io::Error::new(ErrorKind::Other, e))? {
+        match db.get(&key).map_err(|e| io::Error::new(ErrorKind::Other, e))? {
             Some(bytes) => {
                 let block: Block = serde_json::from_slice(&bytes)
                     .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
@@ -41,28 +41,28 @@ pub fn load_chain(path: &str) -> io::Result<Blockchain> {
     Ok(chain)
 }
 
-/// Append new blocks to the parity-db database atomically.
+/// Append new blocks to the RocksDB database atomically.
 /// Existing blocks are left untouched, ensuring durability.
 pub fn save_chain(chain: &Blockchain, path: &str) -> io::Result<()> {
-    let mut opts = Options::with_columns(Path::new(path), 1);
-    let db = Db::open_or_create(&opts).map_err(|e| io::Error::new(ErrorKind::Other, e))?;
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    let db = DB::open(&opts, path).map_err(|e| io::Error::new(ErrorKind::Other, e))?;
     // Find current highest index stored
     let mut index = 0u64;
     loop {
         let key = index.to_le_bytes();
-        match db.get(0, &key).map_err(|e| io::Error::new(ErrorKind::Other, e))? {
+        match db.get(&key).map_err(|e| io::Error::new(ErrorKind::Other, e))? {
             Some(_) => index += 1,
             None => break,
         }
     }
+    let mut batch = WriteBatch::default();
     for block in chain.chain.iter().skip(index as usize) {
         let key = block.index.to_le_bytes();
         let value = serde_json::to_vec(block)?;
-        let mut tx = Transaction::new();
-        tx.put(0, key.to_vec(), value);
-        db.commit(tx)
-            .map_err(|e| io::Error::new(ErrorKind::Other, e))?;
+        batch.put(key, value);
     }
+    db.write(batch).map_err(|e| io::Error::new(ErrorKind::Other, e))?;
     Ok(())
 }
 
@@ -81,14 +81,13 @@ mod tests {
                 .as_nanos()
         ));
         fs::create_dir_all(&dir).unwrap();
-        let mut opts = Options::with_columns(dir.as_path(), 1);
-        let db = Db::open_or_create(&opts).unwrap();
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        let db = DB::open(&opts, &dir).unwrap();
         let genesis = Block::new(0, 0, vec![], "0".into(), None);
         let bad_block = Block::new(1, 0, vec![], "wrong".into(), None);
-        let mut tx = Transaction::new();
-        tx.put(0, 0u64.to_le_bytes().to_vec(), serde_json::to_vec(&genesis).unwrap());
-        tx.put(0, 1u64.to_le_bytes().to_vec(), serde_json::to_vec(&bad_block).unwrap());
-        db.commit(tx).unwrap();
+        db.put(0u64.to_le_bytes(), serde_json::to_vec(&genesis).unwrap()).unwrap();
+        db.put(1u64.to_le_bytes(), serde_json::to_vec(&bad_block).unwrap()).unwrap();
         let res = load_chain(dir.to_str().unwrap());
         fs::remove_dir_all(&dir).unwrap();
         assert!(res.is_err());


### PR DESCRIPTION
## Summary
- remove parity-db and use rocksdb instead
- update README about RocksDB storage
- rewrite storage module for RocksDB

## Testing
- `cargo fmt` *(fails: rustfmt missing)*
- `cargo test` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_687e6a9ce87c8326838f26987caddd14