### PR TITLE
Fix missing PeerList match arm

### DIFF
--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -400,6 +400,10 @@ pub async fn handle_client_with_chain(
                         };
                         handle_chain_response(&mut chain, their_chain);
                     }
+                    NetworkMessage::PeerList(list) => {
+                        println!("[SERIALIZED] Received PeerList: {:?}", list);
+                        peers.merge(&list);
+                    }
                     NetworkMessage::Text(s) => println!("[SERIALIZED] Received Text: {}", s),
                 }
                 let response = b"OK (parsed NetworkMessage)\n";


### PR DESCRIPTION
## Summary
- handle `PeerList` messages inside the async `handle_client_with_chain`

## Testing
- `cargo test` *(fails: failed to download crates due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687fdd064b548326b23f20461321e91e