### PR TITLE
Support configurable genesis recipient

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -12,17 +12,20 @@ pub struct Blockchain {
 }
 
 impl Blockchain {
-    pub fn new() -> Self {
-        let genesis_tx = Transaction {
-            sender: "genesis_address".to_string(),
-            recipient: "first_user".to_string(),
-            amount: 100,
-            signature: None,
+    pub fn new(genesis: Option<(String, u64)>) -> Self {
+        let txs = match genesis {
+            Some((recipient, amount)) => vec![Transaction {
+                sender: "genesis_address".to_string(),
+                recipient,
+                amount,
+                signature: None,
+            }],
+            None => Vec::new(),
         };
         let mut genesis_block = Block::new(
             0,
             0,
-            vec![genesis_tx],
+            txs,
             "0".to_string(),
             None, // <-- Genesis block has no sender_addr
         );
@@ -147,14 +150,14 @@ mod tests {
 
     #[test]
     fn test_blockchain_new_creates_genesis() {
-        let bc = Blockchain::new();
+        let bc = Blockchain::new(None);
         assert_eq!(bc.chain.len(), 1);
         assert_eq!(bc.chain[0].index, 0);
     }
 
     #[test]
     fn test_add_block() {
-        let mut bc = Blockchain::new();
+        let mut bc = Blockchain::new(None);
         let secp = Secp256k1::new();
         let mut rng = OsRng;
         let mut sk_bytes = [0u8; 32];
@@ -181,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_reject_overspend() {
-        let mut bc = Blockchain::new();
+        let mut bc = Blockchain::new(None);
         let secp = Secp256k1::new();
         let mut rng = OsRng;
         let mut sk_bytes = [0u8; 32];
@@ -201,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_reject_double_spend_in_block() {
-        let mut bc = Blockchain::new();
+        let mut bc = Blockchain::new(None);
         let secp = Secp256k1::new();
         let mut rng = OsRng;
         let mut sk_bytes = [0u8; 32];
@@ -228,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_is_valid_chain_detection() {
-        let mut bc = Blockchain::new();
+        let mut bc = Blockchain::new(None);
         let secp = Secp256k1::new();
         let mut rng = OsRng;
         let mut sk_bytes = [0u8; 32];
@@ -251,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_invalid_block_hash_detected() {
-        let mut bc = Blockchain::new();
+        let mut bc = Blockchain::new(None);
         let secp = Secp256k1::new();
         let mut rng = OsRng;
         let mut sk_bytes = [0u8; 32];
@@ -275,7 +278,7 @@ mod tests {
 
     #[test]
     fn test_reject_replayed_transaction() {
-        let mut bc = Blockchain::new();
+        let mut bc = Blockchain::new(None);
         let secp = Secp256k1::new();
         let mut rng = OsRng;
         let mut sk_bytes = [0u8; 32];

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ async fn main() {
         }
         Err(_) => {
             tracing::info!("[STORAGE] Starting new chain");
-            Blockchain::new()
+            Blockchain::new(Some((my_address.clone(), 100)))
         }
     };
     let blockchain = Arc::new(Mutex::new(initial_chain));

--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -710,8 +710,8 @@ mod tests {
 
     #[test]
     fn test_handle_chain_response_replaces_chain() {
-        let mut local = Blockchain::new();
-        let mut their = Blockchain::new();
+        let mut local = Blockchain::new(None);
+        let mut their = Blockchain::new(None);
         let secp = Secp256k1::new();
         let mut rng = OsRng;
         let mut sk_bytes = [0u8; 32];
@@ -780,7 +780,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let mut their_chain = Blockchain::new();
+        let mut their_chain = Blockchain::new(None);
         let secp = Secp256k1::new();
         let mut rng = OsRng;
         let mut sk_bytes = [0u8; 32];
@@ -811,7 +811,7 @@ mod tests {
             }
         });
 
-        let local = Arc::new(Mutex::new(Blockchain::new()));
+        let local = Arc::new(Mutex::new(Blockchain::new(None)));
         let client_sk = SecretKey::from_slice(&sk_bytes).unwrap();
         request_chain_and_reconcile(&addr.to_string(), local.clone(), "client", &client_sk).await;
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -828,8 +828,8 @@ mod tests {
         let addr2 = temp2.local_addr().unwrap();
         drop(temp2);
 
-        let bc1 = Arc::new(Mutex::new(Blockchain::new()));
-        let bc2 = Arc::new(Mutex::new(Blockchain::new()));
+        let bc1 = Arc::new(Mutex::new(Blockchain::new(None)));
+        let bc2 = Arc::new(Mutex::new(Blockchain::new(None)));
         let peers1 = Arc::new(PeerList::new());
         let peers2 = Arc::new(PeerList::new());
         peers1.add_peer(&addr2.to_string());
@@ -917,8 +917,8 @@ mod tests {
 
     #[test]
     fn test_handle_chain_response_rejects_invalid_chain() {
-        let mut local = Blockchain::new();
-        let mut their = Blockchain::new();
+        let mut local = Blockchain::new(None);
+        let mut their = Blockchain::new(None);
         // create a valid extra block then corrupt it
         let secp = Secp256k1::new();
         let mut rng = OsRng;
@@ -946,7 +946,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let bc = Arc::new(Mutex::new(Blockchain::new()));
+        let bc = Arc::new(Mutex::new(Blockchain::new(None)));
         let peers = Arc::new(PeerList::new());
         let sk = Arc::new(SecretKey::from_slice(&[1u8; 32]).unwrap());
 


### PR DESCRIPTION
## Summary
- allow setting a genesis recipient and amount when creating a `Blockchain`
- give a new node an initial balance by passing wallet address in `main.rs`
- adjust blockchain and network tests for the new API

## Testing
- `cargo test --quiet` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687fec8fea248326b12554e4765ad6f5