### PR TITLE
Add wallet balance logging and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ cargo run -- --port 6002 --node-name node2 --peers 127.0.0.1:6001
 ```
 
 Each node will print received messages and you can send transactions via the interactive prompt.
+The prompt also accepts a few commands like `add`, `remove`, `list` and `balance`.
+Use `balance` at any time to print your wallet's current balance.
 
 ## Chain persistence
 


### PR DESCRIPTION
## Summary
- log wallet address and starting balance when a node starts
- provide a `balance` command to inspect the wallet
- mention the `balance` command in README

## Testing
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_687fee1cee0483268edd605ca10f68a3