### PR TITLE
Fix mempool types and async task

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,13 +136,15 @@ async fn main() {
         tokio::spawn(async move {
             loop {
                 sleep(Duration::from_secs(1)).await;
-                let txs = {
+                let txs_opt = {
                     let mut m = mp.lock().unwrap();
                     if m.pending.is_empty() {
-                        continue;
+                        None
+                    } else {
+                        Some(m.drain())
                     }
-                    m.drain()
                 };
+                let Some(txs) = txs_opt else { continue; };
                 let mut chain = bc.lock().unwrap();
                 if chain.add_block(txs, Some(addr.clone())) {
                     if let Err(e) = save_chain(&chain, &chain_dir) {

--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -853,7 +853,7 @@ mod tests {
         let addr1_str = addr1.to_string();
         let server1_bc = bc1.clone();
         let server1_peers = peers1.clone();
-        let server1_mp = Arc::new(Mempool::new());
+        let server1_mp = Arc::new(Mutex::new(Mempool::new()));
         let server1_mp_clone = server1_mp.clone();
         let addr1_my = addr1_str.clone();
         let node1_sk = SecretKey::from_slice(&[1u8; 32]).unwrap();
@@ -868,7 +868,7 @@ mod tests {
         let addr2_str = addr2.to_string();
         let server2_bc = bc2.clone();
         let server2_peers = peers2.clone();
-        let server2_mp = Arc::new(Mempool::new());
+        let server2_mp = Arc::new(Mutex::new(Mempool::new()));
         let server2_mp_clone = server2_mp.clone();
         let addr2_my = addr2_str.clone();
         let node2_sk = SecretKey::from_slice(&[2u8; 32]).unwrap();
@@ -967,7 +967,7 @@ mod tests {
 
         let bc_clone = bc.clone();
         let peers_clone = peers.clone();
-        let mp = Arc::new(Mempool::new());
+        let mp = Arc::new(Mutex::new(Mempool::new()));
         let mp_clone = mp.clone();
         let addr_str = addr.to_string();
         let sk_clone = sk.clone();


### PR DESCRIPTION
## Summary
- wrap mempools in Mutex for server tests
- avoid holding MutexGuard across await when mining loop

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo test --locked --offline` *(fails: no matching package named `clap` found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff86c59488326aaecf7701f92eb8f