### PR TITLE
Fix SignedMessage clone error

### DIFF
--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -117,7 +117,7 @@ impl NetworkMessage {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SignedMessage {
     pub message: VersionedMessage,
     pub signature: String,


### PR DESCRIPTION
## Summary
- derive `Clone` for `SignedMessage` so tests compile

## Testing
- `cargo test` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_68802f17d9c883268871aadd89ec18b1