### PR TITLE
Add encrypted wallet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Each node will print received messages and you can send transactions via the int
 The prompt also accepts a few commands like `add`, `remove`, `list` and `balance`.
 Use `balance` at any time to print your wallet's current balance.
 
+### Wallet encryption
+
+Set the `WALLET_PASSWORD` environment variable before starting a node to
+encrypt the wallet's private key. The file will then be written with an
+`enc:` prefix and must be decrypted using the same password on the next
+run. Without the variable the key is stored as plain hex for backward
+compatibility.
+
 ## Chain persistence
 
 Blocks are now stored in a [RocksDB](https://crates.io/crates/rocksdb) database. The database lives in a directory (default `chain_db`) which can be changed with the `--chain-dir` argument. Each block is written atomically so crashes cannot corrupt previously committed data.

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,6 +1,7 @@
 use rand::rngs::OsRng;
 use rand::RngCore;
 use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::{self, ErrorKind};
 use std::path::Path;
@@ -12,13 +13,35 @@ pub struct Wallet {
 }
 
 impl Wallet {
+    fn xor_with_password(data: &[u8], password: &str) -> Vec<u8> {
+        let mut hasher = Sha256::new();
+        hasher.update(password.as_bytes());
+        let hash = hasher.finalize();
+        data.iter()
+            .zip(hash.iter().cycle())
+            .map(|(b, k)| b ^ k)
+            .collect()
+    }
+
     /// Load an existing wallet from `path`, or generate a new one and persist it.
     pub fn load_or_create<P: AsRef<Path>>(path: P) -> io::Result<Self> {
         let path_ref = path.as_ref();
         if path_ref.exists() {
-            let hex_key = fs::read_to_string(path_ref)?;
-            let key_bytes = hex::decode(hex_key.trim())
-                .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
+            let contents = fs::read_to_string(path_ref)?;
+            let key_bytes = if let Some(enc) = contents.strip_prefix("enc:") {
+                let encrypted = hex::decode(enc.trim())
+                    .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
+                let pass = std::env::var("WALLET_PASSWORD").map_err(|_| {
+                    io::Error::new(
+                        ErrorKind::Other,
+                        "WALLET_PASSWORD not set for encrypted wallet",
+                    )
+                })?;
+                Self::xor_with_password(&encrypted, &pass)
+            } else {
+                hex::decode(contents.trim())
+                    .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?
+            };
             let secret_key = SecretKey::from_slice(&key_bytes)
                 .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
             let secp = Secp256k1::new();
@@ -38,7 +61,12 @@ impl Wallet {
             rng.fill_bytes(&mut sk_bytes);
             let secret_key = SecretKey::from_slice(&sk_bytes)
                 .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
-            fs::write(path_ref, hex::encode(sk_bytes))?;
+            if let Ok(pass) = std::env::var("WALLET_PASSWORD") {
+                let encrypted = Self::xor_with_password(&sk_bytes, &pass);
+                fs::write(path_ref, format!("enc:{}", hex::encode(encrypted)))?;
+            } else {
+                fs::write(path_ref, hex::encode(sk_bytes))?;
+            }
             let public_key = PublicKey::from_secret_key(&secp, &secret_key);
             let address = hex::encode(public_key.serialize());
             Ok(Wallet {
@@ -73,13 +101,17 @@ mod tests {
         ));
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("wallet.key");
+        std::env::set_var("WALLET_PASSWORD", "testpass");
         let w1 = Wallet::load_or_create(&path).unwrap();
         let addr1 = w1.address.clone();
         let sk1 = w1.secret_key.secret_bytes();
         let w2 = Wallet::load_or_create(&path).unwrap();
         assert_eq!(addr1, w2.address);
         assert_eq!(sk1, w2.secret_key.secret_bytes());
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.starts_with("enc:"));
         fs::remove_dir_all(&dir).unwrap();
+        std::env::remove_var("WALLET_PASSWORD");
     }
 
     #[test]
@@ -93,10 +125,12 @@ mod tests {
         ));
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("wallet.key");
+        std::env::set_var("WALLET_PASSWORD", "testpass");
         let wallet = Wallet::load_or_create(&path).unwrap();
         let secp = Secp256k1::new();
         let pk = PublicKey::from_secret_key(&secp, wallet.secret_key());
         assert_eq!(wallet.address(), hex::encode(pk.serialize()));
         fs::remove_dir_all(&dir).unwrap();
+        std::env::remove_var("WALLET_PASSWORD");
     }
 }


### PR DESCRIPTION
## Summary
- introduce optional wallet encryption using WALLET_PASSWORD
- adjust tests for encrypted wallets
- document wallet encryption

## Testing
- `./setup.sh` *(fails: Failed to fetch crates due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688032815694832695fc60089ffad43f