### PR TITLE
Fix TLS variable scope

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,10 @@ async fn main() {
         let addr = server_addr.clone();
         let sk = secret_key.clone();
         let chain_dir = chain_dir.clone();
+        #[cfg(feature = "tls")]
+        let cert_opt = tls_cert.clone();
+        #[cfg(feature = "tls")]
+        let key_opt = tls_key.clone();
         tokio::spawn(async move {
             loop {
                 sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
## Summary
- fix missing TLS `cert_opt` and `key_opt` in mining/broadcast loop

## Testing
- `cargo check --features tls` *(fails: failed to download crates)*
- `./setup.sh` *(fails: missing crates)*

------
https://chatgpt.com/codex/tasks/task_e_688043a799f48326bc0b4e0a8f609ded