### PR TITLE
Add puzzle-based proof-of-work

### DIFF
--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -246,7 +246,7 @@ pub fn handle_chain_response(local_chain: &mut Blockchain, their_chain: Vec<Bloc
             let curr = &their_chain[i];
             if curr.prev_hash != prev.hash
                 || curr.hash != curr.calculate_hash()
-                || !curr.hash.starts_with(DIFFICULTY_PREFIX)
+                || !curr.is_puzzle_valid(DIFFICULTY_PREFIX)
             {
                 valid = false;
                 break;
@@ -254,7 +254,7 @@ pub fn handle_chain_response(local_chain: &mut Blockchain, their_chain: Vec<Bloc
         }
         if valid {
             if their_chain[0].hash != their_chain[0].calculate_hash()
-                || !their_chain[0].hash.starts_with(DIFFICULTY_PREFIX)
+                || !their_chain[0].is_puzzle_valid(DIFFICULTY_PREFIX)
             {
                 valid = false;
             }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -96,8 +96,8 @@ mod tests {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         let db = DB::open(&opts, &dir).unwrap();
-        let genesis = Block::new(0, 0, vec![], "0".into(), None);
-        let bad_block = Block::new(1, 0, vec![], "wrong".into(), None);
+        let genesis = Block::new(0, 0, vec![], "0".into(), None, 0);
+        let bad_block = Block::new(1, 0, vec![], "wrong".into(), None, 1);
         db.put(0u64.to_le_bytes(), serde_json::to_vec(&genesis).unwrap())
             .unwrap();
         db.put(1u64.to_le_bytes(), serde_json::to_vec(&bad_block).unwrap())


### PR DESCRIPTION
## Summary
- replace nonce-based mining with puzzle IDs and solutions
- validate puzzle solutions when adding and reconciling blocks
- compute chain work from puzzle solutions rather than hash prefixes

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6890c32dc5c083269c219bfda7b37ebf