### PR TITLE
Track puzzle activity for PoS rewards

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1,15 +1,25 @@
 use crate::block::Block;
 use crate::transaction::Transaction;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
-use sha2::{Digest, Sha256};
 
 pub const DIFFICULTY_PREFIX: &str = "0000";
+
+/// Address used to mint new tokens as rewards.
+pub const MINT_ADDRESS: &str = "mint";
+/// Number of tokens awarded for solving a puzzle.
+pub const REWARD_AMOUNT: u64 = 50;
+/// Maximum number of tokens that can ever exist.
+pub const MAX_SUPPLY: u64 = 21_000_000;
 
 #[derive(Clone)]
 pub struct Blockchain {
     pub chain: Vec<Block>,
     pub balances: HashMap<String, u64>,
+    pub puzzle_ownership: HashMap<String, u64>,
+    pub puzzle_attempts: HashMap<String, u64>,
+    pub total_supply: u64,
 }
 
 impl Blockchain {
@@ -35,6 +45,9 @@ impl Blockchain {
         let mut bc = Blockchain {
             chain: vec![genesis_block],
             balances: HashMap::new(),
+            puzzle_ownership: HashMap::new(),
+            puzzle_attempts: HashMap::new(),
+            total_supply: 0,
         };
         bc.recompute_balances();
         bc
@@ -42,17 +55,35 @@ impl Blockchain {
 
     pub fn recompute_balances(&mut self) -> bool {
         let mut bals = HashMap::new();
+        let mut ownership = HashMap::new();
+        let mut attempts = HashMap::new();
+        let mut supply = 0u64;
+
         for (idx, block) in self.chain.iter().enumerate() {
+            if idx != 0 {
+                if let Some(addr) = &block.sender_addr {
+                    *ownership.entry(addr.clone()).or_insert(0) += 1;
+                    *attempts.entry(addr.clone()).or_insert(0) += 1;
+                }
+            }
+
             for tx in &block.transactions {
-                if idx != 0 && !tx.verify() {
+                if idx != 0
+                    && tx.sender != "genesis_address"
+                    && tx.sender != MINT_ADDRESS
+                    && !tx.verify()
+                {
                     tracing::info!("[VALIDATION] Invalid tx signature in block {}", idx);
                     return false;
                 }
-                if idx == 0 {
+
+                if tx.sender == "genesis_address" || tx.sender == MINT_ADDRESS {
                     let rbal = bals.get(&tx.recipient).copied().unwrap_or(0);
                     bals.insert(tx.recipient.clone(), rbal + tx.amount);
+                    supply += tx.amount;
                     continue;
                 }
+
                 let sbal = bals.get(&tx.sender).copied().unwrap_or(0);
                 if sbal < tx.amount {
                     tracing::info!("[VALIDATION] Overspend in block {}", idx);
@@ -62,7 +93,11 @@ impl Blockchain {
                 bals.insert(tx.recipient.clone(), rbal + tx.amount);
             }
         }
+
         self.balances = bals;
+        self.puzzle_ownership = ownership;
+        self.puzzle_attempts = attempts;
+        self.total_supply = supply;
         true
     }
 
@@ -86,18 +121,40 @@ impl Blockchain {
         Self::chain_work(&self.chain)
     }
 
-    // Make this function accept sender_addr and return whether the block was added
     pub fn add_block(
         &mut self,
-        transactions: Vec<Transaction>,
+        mut transactions: Vec<Transaction>,
         sender_addr: Option<String>,
     ) -> bool {
         if !transactions.iter().all(|tx| tx.verify()) {
             tracing::info!("[BLOCKCHAIN] Rejected block with invalid transaction signature");
             return false;
         }
+
+        // Mint reward if under cap
+        let mut minted = 0u64;
+        if let Some(addr) = &sender_addr {
+            if self.total_supply + REWARD_AMOUNT <= MAX_SUPPLY {
+                transactions.insert(
+                    0,
+                    Transaction {
+                        sender: MINT_ADDRESS.to_string(),
+                        recipient: addr.clone(),
+                        amount: REWARD_AMOUNT,
+                        signature: None,
+                    },
+                );
+                minted = REWARD_AMOUNT;
+            }
+        }
+
         let mut temp_balances = self.balances.clone();
         for tx in &transactions {
+            if tx.sender == MINT_ADDRESS {
+                let rbal = temp_balances.get(&tx.recipient).copied().unwrap_or(0);
+                temp_balances.insert(tx.recipient.clone(), rbal + tx.amount);
+                continue;
+            }
             let sbal = temp_balances.get(&tx.sender).copied().unwrap_or(0);
             if sbal < tx.amount {
                 tracing::info!("[BLOCKCHAIN] Rejected block - overspend by {}", tx.sender);
@@ -107,6 +164,7 @@ impl Blockchain {
             let rbal = temp_balances.get(&tx.recipient).copied().unwrap_or(0);
             temp_balances.insert(tx.recipient.clone(), rbal + tx.amount);
         }
+
         let last_block = self.chain.last().unwrap();
         let index = last_block.index + 1;
         let timestamp = SystemTime::now()
@@ -114,10 +172,23 @@ impl Blockchain {
             .unwrap()
             .as_millis();
         let prev_hash = last_block.hash.clone();
-        let mut new_block = Block::new(index, timestamp, transactions, prev_hash, sender_addr, index);
+        let mut new_block = Block::new(
+            index,
+            timestamp,
+            transactions,
+            prev_hash,
+            sender_addr.clone(),
+            index,
+        );
         new_block.mine(DIFFICULTY_PREFIX);
         self.chain.push(new_block);
         self.balances = temp_balances;
+
+        if let Some(addr) = sender_addr {
+            *self.puzzle_ownership.entry(addr.clone()).or_insert(0) += 1;
+            *self.puzzle_attempts.entry(addr).or_insert(0) += 1;
+        }
+        self.total_supply += minted;
         true
     }
 
@@ -126,9 +197,7 @@ impl Blockchain {
             return false;
         }
         let genesis = &self.chain[0];
-        if genesis.hash != genesis.calculate_hash()
-            || !genesis.is_puzzle_valid(DIFFICULTY_PREFIX)
-        {
+        if genesis.hash != genesis.calculate_hash() || !genesis.is_puzzle_valid(DIFFICULTY_PREFIX) {
             tracing::info!("Genesis block invalid");
             return false;
         }
@@ -154,6 +223,13 @@ impl Blockchain {
         }
         let mut tmp = self.clone();
         tmp.recompute_balances()
+    }
+
+    pub fn voting_power(&self, addr: &str) -> u64 {
+        let bal = self.balances.get(addr).copied().unwrap_or(0);
+        let owned = self.puzzle_ownership.get(addr).copied().unwrap_or(0);
+        let attempted = self.puzzle_attempts.get(addr).copied().unwrap_or(0);
+        bal + owned + attempted
     }
 }
 
@@ -193,10 +269,16 @@ mod tests {
         assert_eq!(bc.chain.len(), 2);
         let last = bc.chain.last().unwrap();
         assert_eq!(last.index, 1);
-        assert_eq!(last.transactions, vec![tx.clone()]);
+        assert_eq!(last.transactions.len(), 2); // reward + tx
         assert_eq!(last.prev_hash, bc.chain[0].hash);
         assert_eq!(bc.balances.get(&tx.sender).copied(), Some(0));
         assert_eq!(bc.balances.get(&"b".to_string()).copied(), Some(1));
+        assert_eq!(
+            bc.balances.get(&"addr".to_string()).copied(),
+            Some(REWARD_AMOUNT)
+        );
+        assert_eq!(bc.puzzle_ownership.get("addr"), Some(&1));
+        assert_eq!(bc.puzzle_attempts.get("addr"), Some(&1));
     }
 
     #[test]
@@ -315,5 +397,14 @@ mod tests {
         // Replay the same transaction which should now overspend
         assert!(!bc.add_block(vec![tx], Some("addr".into())));
         assert_eq!(bc.chain.len(), 2); // second block rejected
+    }
+
+    #[test]
+    fn test_voting_power_calculation() {
+        let mut bc = Blockchain::new(None);
+        bc.balances.insert("alice".into(), 10);
+        bc.puzzle_ownership.insert("alice".into(), 2);
+        bc.puzzle_attempts.insert("alice".into(), 3);
+        assert_eq!(bc.voting_power("alice"), 15);
     }
 }

--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -28,7 +28,7 @@ use std::sync::Arc as StdArc;
 use tokio_rustls::{TlsAcceptor, TlsConnector, TlsStream};
 
 use crate::block::Block;
-use crate::blockchain::{Blockchain, DIFFICULTY_PREFIX};
+use crate::blockchain::{Blockchain, DIFFICULTY_PREFIX, MINT_ADDRESS};
 use crate::mempool::Mempool;
 use crate::peer::PeerList;
 use crate::transaction::Transaction;
@@ -317,7 +317,11 @@ pub fn handle_client_with_chain(
                     }
                     NetworkMessage::Block(block) => {
                         tracing::info!("[SERIALIZED] Received Block: {:?}", block);
-                        if !block.transactions.iter().all(|tx| tx.verify()) {
+                        if !block
+                            .transactions
+                            .iter()
+                            .all(|tx| tx.sender == MINT_ADDRESS || tx.verify())
+                        {
                             tracing::error!("[SERIALIZED] Block contains invalid transaction");
                             return;
                         }
@@ -457,7 +461,11 @@ pub async fn handle_client_with_chain<S>(
                     }
                     NetworkMessage::Block(block) => {
                         tracing::info!("[SERIALIZED] Received Block: {:?}", block);
-                        if !block.transactions.iter().all(|tx| tx.verify()) {
+                        if !block
+                            .transactions
+                            .iter()
+                            .all(|tx| tx.sender == MINT_ADDRESS || tx.verify())
+                        {
                             tracing::error!("[SERIALIZED] Block contains invalid transaction");
                             return;
                         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -36,6 +36,9 @@ pub fn load_chain(path: &str) -> io::Result<Blockchain> {
     let mut chain = Blockchain {
         chain: blocks,
         balances: HashMap::new(),
+        puzzle_ownership: HashMap::new(),
+        puzzle_attempts: HashMap::new(),
+        total_supply: 0,
     };
     if !chain.is_valid_chain() {
         return Err(io::Error::new(ErrorKind::InvalidData, "invalid blockchain"));


### PR DESCRIPTION
## Summary
- track puzzles owned/attempted per address and total token supply
- mint WordWalk token rewards on solved puzzles with global cap
- base voting power on balance plus puzzle metrics and accept mint txs without signatures

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6890dfd3617c832686c23fa0c7417d4e