### PR TITLE
Add difficulty adjustment to blockchain

### DIFF
--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -261,6 +261,8 @@ pub fn handle_chain_response(local_chain: &mut Blockchain, their_chain: Vec<Bloc
         }
         if valid {
             local_chain.chain = their_chain;
+            local_chain.recompute_balances();
+            local_chain.recompute_difficulty();
             tracing::info!("[RECONCILE] Local chain updated from peer!");
         } else {
             tracing::info!("[RECONCILE] Received invalid chain, ignoring.");

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -39,11 +39,13 @@ pub fn load_chain(path: &str) -> io::Result<Blockchain> {
         puzzle_ownership: HashMap::new(),
         puzzle_attempts: HashMap::new(),
         total_supply: 0,
+        difficulty_prefix: crate::blockchain::DIFFICULTY_PREFIX.to_string(),
     };
     if !chain.is_valid_chain() {
         return Err(io::Error::new(ErrorKind::InvalidData, "invalid blockchain"));
     }
     chain.recompute_balances();
+    chain.recompute_difficulty();
     Ok(chain)
 }
 


### PR DESCRIPTION
## Summary
- track a `difficulty_prefix` on the blockchain and adjust it based on block production time
- persist and recompute difficulty when loading or reconciling chains

## Testing
- `cargo test` *(fails: build hangs compiling librocksdb-sys)*

------
https://chatgpt.com/codex/tasks/task_e_6890f060840c83269d96b75c9981b103