### PR TITLE
Add per-address nonce for replay protection

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -77,9 +77,17 @@ mod tests {
             sender: "a".into(),
             recipient: "b".into(),
             amount: 10,
+            nonce: 0,
             signature: None,
         };
-        let block = Block::new(1, 123, vec![tx.clone()], "prev".into(), Some("me".into()), 1);
+        let block = Block::new(
+            1,
+            123,
+            vec![tx.clone()],
+            "prev".into(),
+            Some("me".into()),
+            1,
+        );
         assert_eq!(block.index, 1);
         assert_eq!(block.timestamp, 123);
         assert_eq!(block.transactions, vec![tx]);
@@ -96,6 +104,7 @@ mod tests {
             sender: "x".into(),
             recipient: "y".into(),
             amount: 5,
+            nonce: 0,
             signature: None,
         };
         let block = Block::new(2, 456, vec![tx], "prevhash".into(), None, 2);
@@ -110,6 +119,7 @@ mod tests {
             sender: "x".into(),
             recipient: "y".into(),
             amount: 1,
+            nonce: 0,
             signature: None,
         };
         let mut block = Block::new(1, 1, vec![tx], "0".into(), None, 3);

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -31,6 +31,7 @@ mod tests {
             sender: "a".into(),
             recipient: "b".into(),
             amount: 2,
+            nonce: 0,
             signature: None,
         };
         mp.add_tx(tx.clone());

--- a/src/network_serialize.rs
+++ b/src/network_serialize.rs
@@ -1035,6 +1035,7 @@ mod tests {
             sender: hex::encode(pk.serialize()),
             recipient: "b".into(),
             amount: 1,
+            nonce: 0,
             signature: None,
         };
         tx.sign(&sk);
@@ -1104,6 +1105,7 @@ mod tests {
             sender: hex::encode(pk.serialize()),
             recipient: "y".into(),
             amount: 5,
+            nonce: 0,
             signature: None,
         };
         tx.sign(&sk);
@@ -1214,6 +1216,7 @@ mod tests {
             sender: hex::encode(pk.serialize()),
             recipient: "b".into(),
             amount: 3,
+            nonce: 0,
             signature: None,
         };
         tx.sign(&sk);
@@ -1265,6 +1268,7 @@ mod tests {
             sender: hex::encode(pk.serialize()),
             recipient: "b".into(),
             amount: 1,
+            nonce: 0,
             signature: None,
         };
         tx.sign(&sk);
@@ -1354,6 +1358,7 @@ mod tests {
             sender: hex::encode(pk.serialize()),
             recipient: "bob".into(),
             amount: 1,
+            nonce: 0,
             signature: None,
         };
         tx.sign(&tx_sk);
@@ -1411,6 +1416,7 @@ mod tests {
             sender: hex::encode(pk.serialize()),
             recipient: "x".repeat(5000),
             amount: 1,
+            nonce: 0,
             signature: None,
         };
         tx.sign(&tx_sk);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -38,6 +38,7 @@ pub fn load_chain(path: &str) -> io::Result<Blockchain> {
         balances: HashMap::new(),
         puzzle_ownership: HashMap::new(),
         puzzle_attempts: HashMap::new(),
+        nonces: HashMap::new(),
         total_supply: 0,
         difficulty_prefix: crate::blockchain::DIFFICULTY_PREFIX.to_string(),
     };
@@ -140,6 +141,7 @@ mod tests {
             sender: sender.clone(),
             recipient: "bob".into(),
             amount: 25,
+            nonce: 0,
             signature: None,
         };
         tx.sign(&sk);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -8,6 +8,7 @@ pub struct Transaction {
     pub sender: String,
     pub recipient: String,
     pub amount: u64,
+    pub nonce: u64,
     pub signature: Option<String>,
 }
 
@@ -17,6 +18,7 @@ impl Transaction {
         hasher.update(&self.sender);
         hasher.update(&self.recipient);
         hasher.update(self.amount.to_be_bytes());
+        hasher.update(self.nonce.to_be_bytes());
         let result = hasher.finalize();
         let mut out = [0u8; 32];
         out.copy_from_slice(&result);
@@ -84,6 +86,7 @@ mod tests {
             sender: hex::encode(pk.serialize()),
             recipient: "bob".into(),
             amount: 5,
+            nonce: 0,
             signature: None,
         };
         tx.sign(&sk);
@@ -102,6 +105,7 @@ mod tests {
             sender: hex::encode(pk.serialize()),
             recipient: "alice".into(),
             amount: 1,
+            nonce: 0,
             signature: None,
         };
         tx.sign(&sk);
@@ -115,6 +119,7 @@ mod tests {
             sender: "deadbeef".into(),
             recipient: "bob".into(),
             amount: 1,
+            nonce: 0,
             signature: Some("zz".into()),
         };
         assert!(!tx.verify());
@@ -131,6 +136,7 @@ mod tests {
             sender: "ff".into(),
             recipient: "bob".into(),
             amount: 1,
+            nonce: 0,
             signature: None,
         };
         tx.sign(&sk);


### PR DESCRIPTION
## Summary
- track per-address nonces and verify them when recomputing balances or accepting a block
- include a nonce in transactions and expose it when creating transactions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6890fb4f08b083268d98ec04cb1aa490