### PR TITLE
Add LaTeX user guide for WWChain

### DIFF
--- a/user-guide/introduction.tex
+++ b/user-guide/introduction.tex
@@ -1,0 +1,2 @@
+\chapter{Introduction}
+WWChain is a minimal blockchain prototype written in Rust. Each node maintains its own chain, shares blocks and transactions over TCP and keeps a simple list of peers. The project exists for learning and experimentation rather than production use.

--- a/user-guide/main.tex
+++ b/user-guide/main.tex
@@ -1,0 +1,16 @@
+\documentclass{book}
+\usepackage[utf8]{inputenc}
+\usepackage{hyperref}
+\title{WWChain User Guide}
+\author{WWChain Developers}
+\begin{document}
+\maketitle
+\tableofcontents
+
+\include{introduction}
+\include{setup}
+\include{running}
+\include{wallet}
+\include{persistence}
+
+\end{document}

--- a/user-guide/persistence.tex
+++ b/user-guide/persistence.tex
@@ -1,0 +1,6 @@
+\chapter{Chain Persistence and Logging}
+Blocks are stored in a RocksDB database. The database lives in a directory (default \texttt{chain\_db}) which can be changed with the \texttt{--chain-dir} argument. Each block is written atomically so crashes cannot corrupt previously committed data.
+
+Output is produced using the \texttt{tracing} framework. Control log verbosity by setting the \texttt{RUST\_LOG} environment variable, for example \texttt{RUST\_LOG=info}.
+
+This project is intended for learning and experimentation only and has not been audited for production use.

--- a/user-guide/running.tex
+++ b/user-guide/running.tex
@@ -1,0 +1,14 @@
+\chapter{Running a Node}
+Launch a node with optional arguments:
+\begin{verbatim}
+cargo run -- --port <PORT> --node-name <NAME> --peers <PEER1,PEER2,...> --chain-dir <DIR> --network <mainnet|testnet>
+\end{verbatim}
+When the \texttt{tls} feature is enabled you can provide certificate paths:
+\begin{verbatim}
+cargo run --features tls -- --tls-cert cert.pem --tls-key key.pem
+\end{verbatim}
+Example starting a testnet node:
+\begin{verbatim}
+cargo run -- --network testnet --port 6001 --node-name node1
+\end{verbatim}
+To run multiple nodes locally, start each in its own terminal and list the other as a peer. The interactive prompt accepts commands like \texttt{add}, \texttt{remove}, \texttt{list} and \texttt{balance}.

--- a/user-guide/setup.tex
+++ b/user-guide/setup.tex
@@ -1,0 +1,6 @@
+\chapter{Installation and Setup}
+Ensure the Rust toolchain is installed. Build the project with:
+\begin{verbatim}
+cargo build
+\end{verbatim}
+This compiles the code and fetches all needed dependencies. The \texttt{./setup.sh} script installs Rust if necessary, runs tests and generates documentation to prepare the environment.

--- a/user-guide/wallet.tex
+++ b/user-guide/wallet.tex
@@ -1,0 +1,4 @@
+\chapter{Wallet and Transactions}
+The wallet manages a secp256k1 key pair and derives your address. It can build and sign transactions using the current blockchain state, so submitting a \texttt{tx} command automatically produces a properly signed transaction. Use \texttt{balance} at any time to view your wallet's current balance.
+
+Set the \texttt{WALLET_PASSWORD} environment variable before starting a node to encrypt the wallet's private key. The file will then be written with an \texttt{enc:} prefix and must be decrypted using the same password on subsequent runs.


### PR DESCRIPTION
## Summary
- add LaTeX-based user guide with chapters for introduction, setup, running nodes, wallet and persistence

## Testing
- `cargo test`
- `pdflatex -output-directory user-guide user-guide/main.tex` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893645870808326b24a9fbdfc3843fb