### PR TITLE
Fix wallet guide environment variable formatting

### DIFF
--- a/user-guide/wallet.tex
+++ b/user-guide/wallet.tex
@@ -1,4 +1,4 @@
 \chapter{Wallet and Transactions}
 The wallet manages a secp256k1 key pair and derives your address. It can build and sign transactions using the current blockchain state, so submitting a \texttt{tx} command automatically produces a properly signed transaction. Use \texttt{balance} at any time to view your wallet's current balance.
 
-Set the \texttt{WALLET_PASSWORD} environment variable before starting a node to encrypt the wallet's private key. The file will then be written with an \texttt{enc:} prefix and must be decrypted using the same password on subsequent runs.
+Set the \texttt{WALLET\_PASSWORD} environment variable before starting a node to encrypt the wallet's private key. The file will then be written with an \texttt{enc:} prefix and must be decrypted using the same password on subsequent runs.


### PR DESCRIPTION
## Summary
- escape underscore in wallet guide so WALLET\_PASSWORD renders correctly

## Testing
- `pdflatex main.tex` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `cargo test` *(fails: build stalled on librocksdb-sys)*

------
https://chatgpt.com/codex/tasks/task_e_68936ad98c9c832682f840f125592c75