### PR TITLE
docs: add testnet puzzle CLI examples

### DIFF
--- a/user-guide/running.tex
+++ b/user-guide/running.tex
@@ -11,4 +11,17 @@ Example starting a testnet node:
 \begin{verbatim}
 cargo run -- --network testnet --port 6001 --node-name node1
 \end{verbatim}
-To run multiple nodes locally, start each in its own terminal and list the other as a peer. The interactive prompt accepts commands like \texttt{add}, \texttt{remove}, \texttt{list} and \texttt{balance}.
+To run multiple nodes locally, start each in its own terminal and list the other as a peer. The interactive prompt supports:
+\begin{itemize}
+\item \texttt{tx <recipient> <amount>} to send a transaction.
+\item \texttt{add <peer\_addr>} to add a peer.
+\item \texttt{remove <peer\_addr>} to drop a peer.
+\item \texttt{list} to show current peers.
+\item \texttt{balance} to display your wallet balance.
+\item \texttt{puzzle-stats [<address>]} (testnet only) to show puzzle ownership and attempt counts.
+\end{itemize}
+Example puzzle queries:
+\begin{verbatim}
+puzzle-stats
+puzzle-stats alice
+\end{verbatim}


### PR DESCRIPTION
## Summary
- document interactive commands including puzzle stats for testnet

## Testing
- `cargo test` *(fails: build hung while compiling librocksdb-sys)*

------
https://chatgpt.com/codex/tasks/task_e_6894e0a3dc408326b92bdf24b5f1b5b2