### PR TITLE
Add regex search to blockchain CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tokio-rustls = { version = "0.24", optional = true }
 rustls = { version = "0.21", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
+regex = "1"
 
 # Arc/Mutex/threading are built-in (std), no crate needed.
 


### PR DESCRIPTION
## Summary
- allow searching blockchain content via a new `search` CLI command
- add regex-based search helper in `Blockchain`
- document search command in CLI help

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f941da2b483269fd5d48cfe97b354