### PR TITLE
wwchain and wordwalk integration

### DIFF
--- a/src/bin/rest_shim.rs
+++ b/src/bin/rest_shim.rs
@@ -3,9 +3,12 @@ use http::StatusCode;
 use axum::http::HeaderMap;
 use serde::Deserialize;
 use std::{env, net::SocketAddr, sync::{Arc, Mutex}};
+use serde_json::{json, Value as JsonValue};
+use tokio::net::TcpStream;
+use tokio::time::{timeout, Duration};
 
 use wwchain::{
-    network_serialize::{send_message, NetworkMessage, request_chain_and_reconcile},
+    network_serialize::{send_message, NetworkMessage, request_chain_and_reconcile, SignedMessage},
     blockchain::Blockchain,
 };
 
@@ -16,6 +19,9 @@ struct AppState {
     peer_addr: String,
     secret: Arc<SecretKey>,
     auth_token: Option<String>,
+    network_label: String,
+    pubkey_hex: String,
+    ephemeral: bool,
 }
 
 #[derive(Deserialize)]
@@ -43,6 +49,20 @@ struct EventReq {
     peer: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct SignedReq {
+    signed: SignedMessage,
+    #[serde(default)]
+    peer: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct VerifyReq {
+    pubkey: String,
+    message: String,
+    signature: String,
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -55,25 +75,36 @@ async fn main() {
         .parse()
         .expect("invalid WWCHAIN_REST_ADDR");
     let secret_hex = env::var("WWCHAIN_SECRET_HEX").ok();
-    let secret = match secret_hex {
-        Some(h) => SecretKey::from_slice(&hex::decode(h).expect("SECRET hex")).expect("secret key"),
+    let (secret, ephemeral) = match secret_hex {
+        Some(h) => (SecretKey::from_slice(&hex::decode(h).expect("SECRET hex")).expect("secret key"), false),
         None => {
             eprintln!("WWCHAIN_SECRET_HEX not set — generating ephemeral key");
             use rand::RngCore;
             let mut bytes = [0u8; 32];
             rand::rngs::OsRng.fill_bytes(&mut bytes);
-            SecretKey::from_slice(&bytes).expect("random secret key")
+            (SecretKey::from_slice(&bytes).expect("random secret key"), true)
         }
     };
     let auth_token = env::var("WWCHAIN_REST_TOKEN").ok();
-    let state = AppState { peer_addr, secret: Arc::new(secret), auth_token };
+    let network_label = env::var("WWCHAIN_NETWORK").unwrap_or_else(|_| "unknown".to_string());
+    // Precompute pubkey hex for info endpoint
+    let secp = secp256k1::Secp256k1::new();
+    let pk = secp256k1::PublicKey::from_secret_key(&secp, &secret);
+    let pubkey_hex = hex::encode(pk.serialize());
+    let state = AppState { peer_addr, secret: Arc::new(secret), auth_token, network_label, pubkey_hex, ephemeral };
 
     let app = Router::new()
-        .route("/health", get(|| async { "ok" }))
+        .route("/health", get(get_health))
+        .route("/info", get(get_info))
+        .route("/balance/:pubkey", get(get_balance))
         .route("/chain", get(get_chain))
         .route("/text", post(post_text))
         .route("/tx", post(post_tx))
         .route("/event", post(post_event))
+        // Forward pre-signed messages created by clients
+        .route("/tx_signed", post(post_tx_signed))
+        .route("/event_signed", post(post_event_signed))
+        .route("/verify_signature", post(post_verify_signature))
         .with_state(state);
 
     tracing::info!("REST shim listening on http://{}", listen_addr);
@@ -84,20 +115,24 @@ async fn main() {
 
 async fn post_text(
     axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<TextReq>,
-) -> Result<&'static str, (StatusCode, String)> {
+) -> Result<&'static str, (StatusCode, Json<JsonValue>)> {
+    check_auth(&state, &headers)?;
     let target = req.peer.unwrap_or_else(|| state.peer_addr.clone());
     let msg = NetworkMessage::Text(req.text);
     send_message(&target, &msg, &state.secret)
         .await
-        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+        .map_err(|e| (StatusCode::BAD_GATEWAY, Json(json!({"error": e.to_string()}))))?;
     Ok("ok")
 }
 
 async fn post_tx(
     axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<TxReq>,
-) -> Result<&'static str, (StatusCode, String)> {
+) -> Result<&'static str, (StatusCode, Json<JsonValue>)> {
+    check_auth(&state, &headers)?;
     use wwchain::transaction::Transaction;
     use secp256k1::{PublicKey, Secp256k1};
 
@@ -116,11 +151,11 @@ async fn post_tx(
     let msg = NetworkMessage::Transaction(tx);
     send_message(&target, &msg, &state.secret)
         .await
-        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+        .map_err(|e| (StatusCode::BAD_GATEWAY, Json(json!({"error": e.to_string()}))))?;
     Ok("ok")
 }
 
-fn check_auth(state: &AppState, headers: &HeaderMap) -> Result<(), (StatusCode, String)> {
+fn check_auth(state: &AppState, headers: &HeaderMap) -> Result<(), (StatusCode, Json<JsonValue>)> {
     if let Some(expected) = &state.auth_token {
         // Accept either X-Auth-Token or Authorization: Bearer <token>
         let header_token = headers
@@ -133,7 +168,7 @@ fn check_auth(state: &AppState, headers: &HeaderMap) -> Result<(), (StatusCode, 
                 })
             });
         if header_token.as_deref() != Some(expected.as_str()) {
-            return Err((StatusCode::UNAUTHORIZED, "invalid auth token".into()));
+            return Err((StatusCode::UNAUTHORIZED, Json(json!({"error": "invalid auth token"}))));
         }
     }
     Ok(())
@@ -143,14 +178,91 @@ async fn post_event(
     axum::extract::State(state): axum::extract::State<AppState>,
     headers: HeaderMap,
     Json(req): Json<EventReq>,
-) -> Result<&'static str, (StatusCode, String)> {
+) -> Result<&'static str, (StatusCode, Json<JsonValue>)> {
     check_auth(&state, &headers)?;
     let target = req.peer.unwrap_or_else(|| state.peer_addr.clone());
     let msg = NetworkMessage::AppEvent { kind: req.kind, data: req.data };
     send_message(&target, &msg, &state.secret)
         .await
-        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+        .map_err(|e| (StatusCode::BAD_GATEWAY, Json(json!({"error": e.to_string()}))))?;
     Ok("ok")
+}
+
+async fn forward_signed(addr: &str, signed: &SignedMessage) -> std::io::Result<()> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut stream = TcpStream::connect(addr).await?;
+    let buf = serde_json::to_vec(&signed)?;
+    let buf = {
+        let len = (buf.len() as u32).to_be_bytes();
+        [len.to_vec(), buf].concat()
+    };
+    stream.write_all(&buf).await?;
+    let mut resp = [0u8; 4096];
+    let _ = stream.read(&mut resp).await.unwrap_or(0);
+    Ok(())
+}
+
+async fn post_tx_signed(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<SignedReq>,
+) -> Result<&'static str, (StatusCode, Json<JsonValue>)> {
+    check_auth(&state, &headers)?;
+    // Basic validation: ensure payload matches Transaction
+    match &req.signed.message.payload {
+        NetworkMessage::Transaction(_) => {}
+        _ => return Err((StatusCode::BAD_REQUEST, Json(json!({"error":"expected Transaction payload"})))),
+    }
+    let target = req.peer.unwrap_or_else(|| state.peer_addr.clone());
+    forward_signed(&target, &req.signed)
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, Json(json!({"error": e.to_string()}))))?;
+    Ok("ok")
+}
+
+async fn post_event_signed(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<SignedReq>,
+) -> Result<&'static str, (StatusCode, Json<JsonValue>)> {
+    check_auth(&state, &headers)?;
+    match &req.signed.message.payload {
+        NetworkMessage::AppEvent { .. } => {}
+        _ => return Err((StatusCode::BAD_REQUEST, Json(json!({"error":"expected AppEvent payload"})))),
+    }
+    let target = req.peer.unwrap_or_else(|| state.peer_addr.clone());
+    forward_signed(&target, &req.signed)
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, Json(json!({"error": e.to_string()}))))?;
+    Ok("ok")
+}
+
+async fn post_verify_signature(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<VerifyReq>,
+) -> Result<Json<JsonValue>, (StatusCode, Json<JsonValue>)> {
+    // optional auth: only enforce if token configured
+    check_auth(&state, &headers)?;
+    // Decode pubkey and signature
+    use secp256k1::{ecdsa::Signature, PublicKey, Secp256k1, Message};
+    let pub_bytes = match hex::decode(&req.pubkey) { Ok(b) => b, Err(_) => return Ok(Json(json!({"valid": false, "error": "invalid pubkey hex"}))) };
+    let sig_bytes = match hex::decode(&req.signature) { Ok(b) => b, Err(_) => return Ok(Json(json!({"valid": false, "error": "invalid signature hex"}))) };
+    let pubkey = match PublicKey::from_slice(&pub_bytes) { Ok(p) => p, Err(_) => return Ok(Json(json!({"valid": false, "error": "invalid pubkey format"}))) };
+    let sig = match Signature::from_compact(&sig_bytes) { Ok(s) => s, Err(_) => return Ok(Json(json!({"valid": false, "error": "invalid signature format"}))) };
+    let digest = {
+        use sha2::{Sha256, Digest};
+        let mut h = Sha256::new();
+        h.update(req.message.as_bytes());
+        let d = h.finalize();
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&d);
+        out
+    };
+    let msg = match Message::from_slice(&digest) { Ok(m) => m, Err(_) => return Ok(Json(json!({"valid": false, "error": "invalid digest"}))) };
+    let secp = Secp256k1::verification_only();
+    let ok = secp.verify_ecdsa(&msg, &sig, &pubkey).is_ok();
+    Ok(Json(json!({"valid": ok})))
 }
 
 async fn get_chain(
@@ -158,6 +270,14 @@ async fn get_chain(
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     // Build a temporary local blockchain and fetch the peer chain into it
     let bc = Arc::new(Mutex::new(Blockchain::new(None)));
+    {
+        // Align local validation difficulty with configured network (testnet uses lighter target)
+        if state.network_label.eq_ignore_ascii_case("testnet") {
+            if let Ok(mut g) = bc.lock() {
+                g.difficulty_prefix = "00".into();
+            }
+        }
+    }
     // Request and reconcile from peer; ignore errors but try
     request_chain_and_reconcile(&state.peer_addr, bc.clone(), "rest_shim", &state.secret).await;
     let chain = {
@@ -165,4 +285,77 @@ async fn get_chain(
         serde_json::to_value(&guard.chain).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
     };
     Ok(Json(chain))
+}
+
+async fn get_health(
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> Json<JsonValue> {
+    let (peer_reachable, peer_error) = peer_status(&state).await;
+    Json(json!({
+        "status": "ok",
+        "peer_reachable": peer_reachable,
+        "peer_error": peer_error,
+    }))
+}
+
+async fn get_info(
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> Json<JsonValue> {
+    let (peer_reachable, _err) = peer_status(&state).await;
+    let bc = Arc::new(Mutex::new(Blockchain::new(None)));
+    if state.network_label.eq_ignore_ascii_case("testnet") {
+        if let Ok(mut g) = bc.lock() { g.difficulty_prefix = "00".into(); }
+    }
+    // Best-effort height probe
+    request_chain_and_reconcile(&state.peer_addr, bc.clone(), "rest_shim", &state.secret).await;
+    let (height, last_hash, last_time_ms, next_nonce) = match bc.lock() {
+        Ok(g) => {
+            let h = g.chain.len();
+            let (hh, ts) = g.chain.last().map(|b| (b.hash.clone(), b.timestamp)).unwrap_or_default();
+            let nn = g.nonces.get(&state.pubkey_hex).copied().unwrap_or(0);
+            (h, hh, ts as u64, nn)
+        }
+        Err(_) => (0, String::new(), 0, 0),
+    };
+    Json(json!({
+        "pubkey_hex": state.pubkey_hex,
+        "peer_addr": state.peer_addr,
+        "network": state.network_label,
+        "height": height,
+        "peer_reachable": peer_reachable,
+        "last_block_hash": last_hash,
+        "last_block_timestamp_ms": last_time_ms,
+        "next_nonce": next_nonce,
+        "ephemeral": state.ephemeral,
+    }))
+}
+
+async fn get_balance(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Path(pubkey): axum::extract::Path<String>,
+) -> Result<Json<JsonValue>, (StatusCode, Json<JsonValue>)> {
+    let bc = Arc::new(Mutex::new(Blockchain::new(None)));
+    if state.network_label.eq_ignore_ascii_case("testnet") {
+        if let Ok(mut g) = bc.lock() { g.difficulty_prefix = "00".into(); }
+    }
+    request_chain_and_reconcile(&state.peer_addr, bc.clone(), "rest_shim", &state.secret).await;
+    let res = {
+        match bc.lock() {
+            Ok(guard) => {
+                let bal = guard.balances.get(&pubkey).copied().unwrap_or(0);
+                let next_nonce = guard.nonces.get(&pubkey).copied().unwrap_or(0);
+                Ok(Json(json!({"pubkey": pubkey, "balance": bal, "height": guard.chain.len(), "next_nonce": next_nonce})))
+            }
+            Err(_) => Err((StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "mutex poisoned"}))))
+        }
+    };
+    res
+}
+
+async fn peer_status(state: &AppState) -> (bool, Option<String>) {
+    match timeout(Duration::from_millis(300), TcpStream::connect(&state.peer_addr)).await {
+        Ok(Ok(_stream)) => (true, None),
+        Ok(Err(e)) => (false, Some(e.to_string())),
+        Err(_) => (false, Some("timeout".into())),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,8 +432,14 @@ async fn main() {
                         e.into_inner()
                     }
                 };
-                let bal = wallet.balance(&bc);
-                tracing::info!("Balance for {}: {}", my_address, bal);
+                if parts.len() == 2 {
+                    let addr = parts[1];
+                    let bal = bc.balances.get(addr).copied().unwrap_or(0);
+                    tracing::info!("Balance for {}: {}", addr, bal);
+                } else {
+                    let bal = wallet.balance(&bc);
+                    tracing::info!("Balance for {}: {}", my_address, bal);
+                }
             }
             "puzzle-stats" if matches!(network, Network::Testnet) => {
                 let bc = match blockchain.lock() {

--- a/user-guide/main.tex
+++ b/user-guide/main.tex
@@ -1,6 +1,10 @@
 \documentclass{book}
 \usepackage[utf8]{inputenc}
 \usepackage{hyperref}
+% Better font encoding for typewriter and symbols in \texttt
+\usepackage[T1]{fontenc}
+% Optional: nicer quotes in verbatim/code
+\usepackage{upquote}
 \title{WWChain User Guide}
 \author{WWChain Developers}
 \begin{document}

--- a/user-guide/running.tex
+++ b/user-guide/running.tex
@@ -51,14 +51,31 @@ cargo run --bin rest_shim
 
 \subsection{Endpoints}
 \begin{itemize}
-\item \texttt{GET /health} \to ``ok''
-\item \texttt{POST /text} with \texttt{\{ "text": "hi", "peer": "127.0.0.1:6001"? \}} \to signed \texttt{Text}
-\item \texttt{POST /event} with \texttt{\{ "kind": "puzzle\_complete", "data": \{...\}, "peer"? \}} \to signed \texttt{AppEvent}
-\item \texttt{POST /tx} with \texttt{\{ "recipient": "<hex pub>", "amount": 1, "nonce": 42, "peer"? \}} \to signed \texttt{Transaction}
+\item \texttt{GET /health} $\to$ JSON with \texttt{status}, \texttt{peer\_reachable}
+\item \texttt{GET /info} $\to$ JSON \texttt{\{ pubkey\_hex, peer\_addr, network, height, peer\_reachable \}}
+\item \texttt{POST /text} with \texttt{\{ "text": "hi", "peer": "127.0.0.1:6001"? \}} $\to$ signed \texttt{Text}
+\item \texttt{POST /event} with \texttt{\{ "kind": "puzzle\_complete", "data": \{...\}, "peer"? \}} $\to$ signed \texttt{AppEvent}
+\item \texttt{POST /tx} with \texttt{\{ "recipient": "<hex pub>", "amount": 1, "nonce": 42, "peer"? \}} $\to$ signed \texttt{Transaction}
+\item \texttt{GET /balance/<pubkey>} $\to$ JSON \texttt{\{ pubkey, balance, height, next\_nonce \}}
 \item \texttt{GET /chain} returns the full chain as JSON (list of blocks).
+\item \textbf{Client-signed forwarding}:
+  \begin{itemize}
+  \item \texttt{POST /tx\_signed} with \texttt{\{ "signed": SignedMessage, "peer"? \}}; requires \texttt{Transaction} payload inside \texttt{SignedMessage}
+  \item \texttt{POST /event\_signed} with \texttt{\{ "signed": SignedMessage, "peer"? \}}; requires \texttt{AppEvent} payload inside \texttt{SignedMessage}
+  \end{itemize}
+\item \textbf{Signature verification}: \texttt{POST /verify\_signature} with \texttt{\{ "pubkey": "<66 hex>", "message": "<utf8>", "signature": "<128 hex>" \}} $\to$ JSON \texttt{\{ valid: bool \}}
 \end{itemize}
 
-When \texttt{WWCHAIN\_REST\_TOKEN} is set the shim requires either an \texttt{X-Auth-Token} header or \texttt{Authorization: Bearer <token>} on POST requests.
+When \texttt{WWCHAIN\_REST\_TOKEN} is set the shim requires either an \texttt{X-Auth-Token} header or \texttt{Authorization: Bearer <token>} on POST requests (\texttt{/text}, \texttt{/event}, \texttt{/tx}).
+
+\subsection{Client-signed flow}
+For non-custodial clients (e.g., browser wallets) that hold their own keys:
+\begin{enumerate}
+\item Build a \texttt{NetworkMessage} (\texttt{Transaction} or \texttt{AppEvent}).
+\item Wrap it in \texttt{VersionedMessage} (\texttt{\{version:1, payload\}}), serialize, and sign its SHA-256 digest with secp256k1 (64-byte compact), producing a \texttt{SignedMessage}.
+\item Send the \texttt{SignedMessage} to \texttt{/tx\_signed} or \texttt{/event\_signed}.
+\end{enumerate}
+Use \texttt{/verify\_signature} to verify ECDSA signatures over arbitrary UTF-8 messages (e.g., one-time challenges) given a compressed secp256k1 public key.
 
 \subsection{AppEvent structure}
 For structured application messages the shim sends a signed \texttt{AppEvent}:
@@ -85,3 +102,14 @@ python manage.py summarize_chain_events --period day --days 14 --source both
 \end{itemize}
 
 For production deployments keep the shim bound to localhost, enable token auth, and leave \texttt{CHAIN\_EVENTS\_ENABLED} off until integration is planned.
+
+\section{Chains, Difficulty, and Testnet}
+Mainnet and testnet differ in difficulty targets. The node automatically lowers difficulty for testnet mining; the shim aligns validation during reconciliation so that \texttt{/info}, \texttt{/balance}, and \texttt{/chain} reflect the correct testnet chain.
+
+\section{CLI Tips}
+From the node prompt:
+\begin{itemize}
+\item \texttt{balance} prints this node's wallet balance.
+\item \texttt{balance <pubkey>} prints the balance for an arbitrary address.
+\item \texttt{tx <recipient> <amount>} mines immediately in a single-node setup.
+\end{itemize}


### PR DESCRIPTION
Summary

- Add client-signed forwarding endpoints to the REST shim: POST /tx_signed, POST /event_signed
- Add signature verification endpoint: POST /verify_signature
- Fix reconciliation on testnet by validating incoming blocks with the local difficulty target instead of a hardcoded prefix
- Improve node CLI: balance  now reports arbitrary address balances

Motivation

- Enable non-custodial clients (e.g., Wordwalk UI) to sign locally and forward signed payloads without exposing private keys to the server
- Provide a simple signature verification utility for registration/attestation flows
- Align shim chain validation with node network difficulty (00 on testnet) so /info and /balance reflect the correct chain
- Improve dev UX by allowing quick balance checks for any pubkey from the node prompt

Changes

- wwchain/src/bin/rest_shim.rs
    - New routes
    - POST /tx_signed: accepts { signed: SignedMessage, peer? } for Transaction payloads
    - POST /event_signed: accepts { signed: SignedMessage, peer? } for AppEvent payloads
    - POST /verify_signature: accepts { pubkey, message, signature } and returns { valid: bool }
- 
Forwarding helper: forwards a SignedMessage as length-prefixed JSON; returns “ok” on TCP success
- 
Info payload adds "ephemeral": whether the shim is using a transient signing key (no WWCHAIN_SECRET_HEX set)
- 
Difficulty alignment: for testnet (WWCHAIN_NETWORK=testnet), set the temporary local blockchain’s difficulty_prefix to "00" before reconciliation for /chain, /
info, /balance
- 
Token auth unchanged: keeps X-Auth-Token / Authorization: Bearer support
- 
wwchain/src/network_serialize.rs
    - Reconcile fix: handle_chain_response now validates incoming blocks with local_chain.difficulty_prefix instead of DIFFICULTY_PREFIX, ensuring testnet chains
are accepted when local difficulty is “00”
- 
wwchain/src/main.rs
    - CLI: balance  shows the specified address’s balance; balance (no args) still shows the node wallet’s balance

Testing

- Build + unit tests
    - cargo build
    - cargo test → 41 passed
- Manual run (testnet)
    - Terminal 1 (node):
    - cargo run --bin wwchain -- --network testnet --port 6001 --chain-dir test_chain_db
- Terminal 2 (shim):
    - export WWCHAIN_PEER_ADDR=127.0.0.1:6001
    - export WWCHAIN_REST_ADDR=127.0.0.1:7000
    - export WWCHAIN_NETWORK=testnet
    - export WWCHAIN_SECRET_HEX=$(openssl rand -hex 32)  # optional but recommended
    - cargo run --bin rest_shim
- Smoke checks
    - GET /health → {status:"ok", peer_reachable:true}
    - GET /info → includes height, pubkey_hex, network, peer_reachable, ephemeral
    - GET /balance/ → returns balance/next_nonce
    - POST /text with {"text":"hi"}:
    - Node logs: [SERIALIZED] Received Text: hi
    - Shim logs: [SERIALIZED] Server responded: OK (parsed NetworkMessage)
- POST /event with {"kind":"ping","data":{}}:
    - Node logs: [SERIALIZED] Received AppEvent kind=ping …
- POST /verify_signature with a valid (pubkey,message,signature) → {"valid":true}
- POST /tx_signed or /event_signed with a SignedMessage payload → OK, and node logs show the received message

API Details

- POST /tx_signed
    - JSON: { "signed": SignedMessage, "peer"?: "host:port" }
    - Requires signed.message.payload = Transaction
- POST /event_signed
    - JSON: { "signed": SignedMessage, "peer"?: "host:port" }
    - Requires signed.message.payload = AppEvent
- POST /verify_signature
    - JSON: { "pubkey": "<66 hex>", "message": "", "signature": "<128 hex compact>" }
    - Response: { "valid": true|false }
- Notes:
    - Token auth applies if WWCHAIN_REST_TOKEN is set (X-Auth-Token or Authorization: Bearer)
    - SignedMessage schema unchanged: {"message":{"version":1,"payload":...},"signature":"<hex>","pubkey":"<hex>"}; signature is ECDSA secp256k1 over
SHA-256(serialized VersionedMessage)
- Tests continue to pass

Operational Notes

- “early eof” in node logs is benign (shim closes the socket after reading)
- For stable shim identity across restarts, set WWCHAIN_SECRET_HEX to a 32-byte hex string
- To see chain data in dev/test quickly, send a tx to force mining (single-node auto-mines on tx)

Suggested Review Focus

- Security of SignedMessage forwarding (passes through as-is; node verify enforces signatures)
- Reconcile difficulty use of local_chain.difficulty_prefix (testnet)
- CLI balance  behavior
- REST shim logs + error handling on forwarding failures

Example SignedMessage (Transaction)
{
"signed": {
    "message": {"version": 1, "payload": {"Transaction": {"sender": "...", "recipient": "...", "amount": 1, "nonce": 0, "signature": "..."}}},
    "signature": "<hex-ecdsa-compact-over-versioned-message>",
    "pubkey": "<sender-compressed-pubkey-hex>"
}
}

Branch/Commit Suggestions

- Branch: feature/rest-signed-forwarding-and-verify
- Commits:
    - rest_shim: add /tx_signed, /event_signed, /verify_signature
    - reconcile: validate with local difficulty; testnet alignment in shim
    - cli: support balance 

